### PR TITLE
Fix dynamic history range

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to use volume profile instead of TPO profile (based on price), then 
 
 ## What is new
 
- The old code was for the local data while this one fetches the live data for BTC-USD directly from Binance servers in 30 minute format for last 10 days (binance limitation) You can use it for any other pair supported by Binance. Fetching the data part is actually very small. Any URL that supports 30-minute data with a minimum history of 10 days will work with this code.
+ The old code was for the local data while this one fetches the live data for BTC-USD directly from Binance servers.  It now loads only the last four complete days of history plus today's session.
 
 Wrote one big class for all market profile and day ranking related calculations instead of functions which is the heart of the code. It also means no repeat calculations and more readable code
 

--- a/btc_mp_v1.py
+++ b/btc_mp_v1.py
@@ -1,8 +1,6 @@
 from MP import MpFunctions
 import requests
-import dash
-import dash_core_components as dcc
-import dash_html_components as html
+from dash import Dash, dcc, html
 from dash.dependencies import Input, Output
 import pandas as pd
 import plotly.graph_objs as go
@@ -12,7 +10,7 @@ import warnings
 
 warnings.filterwarnings('ignore')
 
-app = dash.Dash(__name__)
+app = Dash(__name__)
 
 def get_ticksize(data, freq=30):
     # data = dflive30
@@ -44,9 +42,32 @@ def get_data(url):
     return df
 
 
-url_30m = "https://www.binance.com/api/v1/klines?symbol=BTCBUSD&interval=30m"  # 10 days history 30 min ohlcv
-df = get_data(url_30m)
-df.to_csv('btcusd30m.csv', index=False)
+def get_recent_history(days=4, symbol="BTCBUSD", interval="30m"):
+    """Return recent historical data.
+
+    Parameters
+    ----------
+    days : int
+        Number of full days of history to retrieve prior to today.
+    symbol : str
+        Trading pair symbol.
+    interval : str
+        Binance interval string.
+    """
+    now = dt.datetime.utcnow()
+    start = (now - dt.timedelta(days=days)).replace(hour=0, minute=0, second=0, microsecond=0)
+    end = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    start_ms = int(start.timestamp() * 1000)
+    end_ms = int(end.timestamp() * 1000)
+    url = (
+        f"https://api.binance.com/api/v3/klines?symbol={symbol}"
+        f"&interval={interval}&startTime={start_ms}&endTime={end_ms}"
+    )
+    return get_data(url)
+
+
+# Load last four complete days plus today's session
+df = get_recent_history(days=4)
 
 # params
 context_days = len([group[1] for group in df.groupby(df.index.date)])  # Number of days used for context
@@ -77,7 +98,10 @@ date_mark = {str(h): {'label': str(h), 'style': {'color': 'blue', 'fontsize': '4
                                                  'text-orientation': 'upright'}} for h in range(0, len(dates))}
 
 mp = MpFunctions(data=df.copy(), freq=freq, style=mode, avglen=avglen, ticksize=ticksz, session_hr=trading_hr)
-mplist = mp.get_context()
+mplist_full = mp.get_context()
+# Drop today's partial session from historical context
+listmp_hist = mplist_full[0][:-1]
+distribution_hist = mplist_full[1].iloc[:-1].reset_index(drop=True)
 
 app.layout = html.Div(
     html.Div([
@@ -114,8 +138,8 @@ app.layout = html.Div(
                Input('slider', 'value')
                ])
 def update_graph(n, value):
-    listmp_hist = mplist[0]
-    distribution_hist = mplist[1]
+    # Use precomputed historical context
+    global listmp_hist, distribution_hist
 
     url_1m = "https://www.binance.com/api/v1/klines?symbol=BTCBUSD&interval=1m"
 


### PR DESCRIPTION
## Summary
- fetch only the last four complete days of history
- include today's session and drop historical partial day
- update Dash imports for new module locations
- document new behavior in README

## Testing
- `python -m py_compile btc_mp_v1.py MP.py`


------
https://chatgpt.com/codex/tasks/task_e_68490f3a6aec832fa7af0abad061d8c0