### PR TITLE
Fix dynamic history range

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to use volume profile instead of TPO profile (based on price), then 
 
 ## What is new
 
- The old code was for the local data while this one fetches the live data for BTC-USD directly from Binance servers in 30 minute format for last 10 days (binance limitation) You can use it for any other pair supported by Binance. Fetching the data part is actually very small. Any URL that supports 30-minute data with a minimum history of 10 days will work with this code.
+ The old code was for the local data while this one fetches the live data for BTC-USD directly from Binance servers.  It now loads only the last four complete days of history plus today's session.
 
 Wrote one big class for all market profile and day ranking related calculations instead of functions which is the heart of the code. It also means no repeat calculations and more readable code
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to use volume profile instead of TPO profile (based on price), then 
 
 ## What is new
 
- The old code was for the local data while this one fetches the live data for BTC-USD directly from Binance servers.  It now loads only the last four complete days of history plus today's session.
+ The old code was for the local data while this one fetches the live data for BTC-USD directly from Binance servers.  It now loads only the last four complete days of history plus today's session.  The requests first try the main Binance domain and fall back to the alternate API domain if needed.
 
 Wrote one big class for all market profile and day ranking related calculations instead of functions which is the heart of the code. It also means no repeat calculations and more readable code
 

--- a/btc_mp_v1.py
+++ b/btc_mp_v1.py
@@ -152,9 +152,15 @@ def update_graph(n, value):
     # Use precomputed historical context
     global listmp_hist, distribution_hist
 
-    url_1m = "https://www.binance.com/api/v1/klines?symbol=BTCBUSD&interval=1m"
+    def get_live_data(symbol="BTCBUSD", interval="1m"):
+        url = f"https://www.binance.com/api/v1/klines?symbol={symbol}&interval={interval}"
+        try:
+            return get_data(url)
+        except Exception:
+            alt_url = f"https://api.binance.com/api/v1/klines?symbol={symbol}&interval={interval}"
+            return get_data(alt_url)
 
-    df_live1 = get_data(url_1m)  # this line fetches new data for current day
+    df_live1 = get_live_data()  # fetch new data for current day
     df_live1 = df_live1.dropna()
 
     dflive30 = df_live1.resample('30min').agg({'datetime': 'last', 'Open': 'first', 'High': 'max', 'Low': 'min',


### PR DESCRIPTION
## Summary
- fetch only the last four complete days of history
- include today's session and drop historical partial day
- update Dash imports for new module locations
- handle empty responses from Binance gracefully
- document new behavior in README
- fallback to alternate Binance domain if history request is empty

## Testing
- `python -m py_compile btc_mp_v1.py MP.py`


------
https://chatgpt.com/codex/tasks/task_e_68490f3a6aec832fa7af0abad061d8c0